### PR TITLE
Nuget package creation

### DIFF
--- a/HtmlBuilders/BuildAndPushPackage.cmd
+++ b/HtmlBuilders/BuildAndPushPackage.cmd
@@ -1,0 +1,35 @@
+@echo off
+set thisScriptFilename=%~n0%~x0
+
+rem -- check if current dir is correct
+if not exist %thisScriptFilename% echo ------------- Please call from project-folder as current dir!
+if not exist %thisScriptFilename% goto ende
+
+set releaseFolder=.\bin\Release\
+
+rem -- remove old packages if any
+if exist "%releaseFolder%*.nupkg" del %releaseFolder%*.nupkg
+
+
+msbuild /p:Configuration=Release /t:Rebuild
+IF NOT %ERRORLEVEL%==0 echo ------------- PLEASE execute from 'Developer Command Prompt'!
+IF NOT %ERRORLEVEL%==0 GOTO ende
+
+msbuild /p:Configuration=Release /t:BuildPackage
+IF NOT %ERRORLEVEL%==0 GOTO ende
+
+
+rem -- remove source-packages if any
+if exist "%releaseFolder%*symbols.nupkg" del "%releaseFolder%*symbols.nupkg"
+
+rem -- find and set filename for new package
+FOR %%f in ("%releaseFolder%*.nupkg") DO set package=%%f
+
+echo.
+echo.
+echo ---- INFO: Use '..\.nuget\NuGet.exe setApiKey [YourKey]' if you push the first time on this machine
+echo.
+..\.nuget\nuget push "%package%"
+IF NOT %ERRORLEVEL%==0 GOTO ende
+
+:ende

--- a/HtmlBuilders/HtmlBuilders.csproj
+++ b/HtmlBuilders/HtmlBuilders.csproj
@@ -83,6 +83,10 @@
     <Compile Include="ExtensionsForHtmlTag.TogglableAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="BuildAndPushPackage.cmd" />
+    <None Include="HtmlBuilders.nuspec">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/HtmlBuilders/HtmlBuilders.nuspec
+++ b/HtmlBuilders/HtmlBuilders.nuspec
@@ -18,5 +18,8 @@
         <dependency id="Microsoft.AspNet.Mvc" version="4.0.20505" />
       </group>
     </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Web" />
+    </frameworkAssemblies>
   </metadata>
 </package>

--- a/HtmlBuilders/HtmlBuilders.nuspec
+++ b/HtmlBuilders/HtmlBuilders.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>HtmlBuilders</id>
+    <version>$version$</version>
+    <title>HtmlBuilders</title>
+    <authors>$author$</authors>
+    <owners>Alexander Moerman</owners>
+    <projectUrl>https://github.com/amoerie/htmlbuilders</projectUrl>
+    <iconUrl>http://i.imgur.com/WYsbvbx.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A faster and easier way to parse and create HTML in C#.</description>
+    <releaseNotes>$description$</releaseNotes>
+    <tags>HTML, parsing, creating</tags>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="HtmlAgilityPack" version="1.4.6" />
+        <dependency id="Microsoft.AspNet.Mvc" version="4.0.20505" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/HtmlBuilders/Properties/AssemblyInfo.cs
+++ b/HtmlBuilders/Properties/AssemblyInfo.cs
@@ -6,10 +6,23 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("HtmlBuilders")]
-[assembly: AssemblyDescription("")]
+#region Update this region before creating a new release with 'BuildAndPushPackage.cmd'
+
+// Versioning uses Semantic Versioning 2.0.0 (http://semver.org/): MAJOR.MINOR.PATCH.<UNUSED>
+
+[assembly: AssemblyInformationalVersion("2.0.5")]
+[assembly: AssemblyVersion("2.0.5.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]
+[assembly: AssemblyDescription( // put releaseNotes in here:
+    "2.0.5: Updated NuGet package file to reflect downgraded minimum .NET MVC version.\n" +
+    "2.0.4: Downgraded required .NET MVC version from 5.2 to 4.0 to increase availability.\n" +
+    "2.0.3: Updated 'Merge' to include class, fix encoding issue with quotes in attributes.\n" +
+    "2.0.1: Built in release, had some errors during latest publish so this is mostly a republish just to be safe.")]
+
+#endregion
+
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Alexander Moerman")]
 [assembly: AssemblyProduct("HtmlBuilders")]
 [assembly: AssemblyCopyright("Copyright ©  2013")]
 [assembly: AssemblyTrademark("")]
@@ -22,20 +35,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-
 [assembly: Guid("d90bb1d0-6f1d-48db-b4a8-32d32a641ec7")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo("HtmlBuilders.Tests")]

--- a/HtmlBuilders/Properties/AssemblyInfo.cs
+++ b/HtmlBuilders/Properties/AssemblyInfo.cs
@@ -10,10 +10,11 @@ using System.Runtime.InteropServices;
 
 // Versioning uses Semantic Versioning 2.0.0 (http://semver.org/): MAJOR.MINOR.PATCH.<UNUSED>
 
-[assembly: AssemblyInformationalVersion("2.0.5")]
-[assembly: AssemblyVersion("2.0.5.0")]
-[assembly: AssemblyFileVersion("2.0.5.0")]
+[assembly: AssemblyInformationalVersion("2.0.6")]
+[assembly: AssemblyVersion("2.0.6.0")]
+[assembly: AssemblyFileVersion("2.0.6.0")]
 [assembly: AssemblyDescription( // put releaseNotes in here:
+    "2.0.6: Added reference to System.Web to NuGet-Package to allow successful installation in empty-project. \n" +
     "2.0.5: Updated NuGet package file to reflect downgraded minimum .NET MVC version.\n" +
     "2.0.4: Downgraded required .NET MVC version from 5.2 to 4.0 to increase availability.\n" +
     "2.0.3: Updated 'Merge' to include class, fix encoding issue with quotes in attributes.\n" +


### PR DESCRIPTION
# 1) Package Creation
Tried to improve the Build (as Release) and Push (to NuGet) process. 
I included the .nuspec-file to have this information also under source-control.
Also it could be useful to have the version-number inside the dll - otherwise all will display "1.0.0.0", so now the AssemblyInfo drives the versioning.

**Now it is easy to build and push a new version:**
After the code change:
1. update AssemblyInfo (versions and release-notes)
2. run all tests
3. commit
4. execute HtmlBuilders/BuildAndPushPackage.cmd
5. [tag commit in git as "release_n.n.n"]

If you have already another process or any feedback please let me know.

# 2) System.Web reference
I had problems to add the nuget-package to an empty project without System.Web-reference. 
The reference is needed (e.g: for IHtmlString) and the developer had to add it manually.
I added the reference to the .nuspec and now it works in all cases.

regards 
  Christian