### PR TITLE
Add .NET 9 and .NET 10 multi-targeting, update NuGet packages and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
       - name: Restore tools
         run: dotnet tool restore
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release</Configurations>
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+    <PackageVersion Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.console" Version="2.9.2">
+    <PackageVersion Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/HtmlBuilders.Tests/HtmlBuilders.Tests.csproj
+++ b/HtmlBuilders.Tests/HtmlBuilders.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector">

--- a/HtmlBuilders/HtmlBuilders.csproj
+++ b/HtmlBuilders/HtmlBuilders.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>8.0.0</Version>
@@ -18,7 +18,6 @@
     <Copyright>MIT</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="HtmlAgilityPack" />
   </ItemGroup>
 </Project>

--- a/HtmlBuilders/HtmlBuilders.csproj
+++ b/HtmlBuilders/HtmlBuilders.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>8.0.0</Version>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>

--- a/HtmlBuilders/HtmlBuilders.csproj
+++ b/HtmlBuilders/HtmlBuilders.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>8.0.0</Version>
@@ -18,6 +18,7 @@
     <Copyright>MIT</Copyright>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="HtmlAgilityPack" />
   </ItemGroup>
 </Project>

--- a/HtmlBuilders/HtmlTag.cs
+++ b/HtmlBuilders/HtmlTag.cs
@@ -540,10 +540,7 @@ public sealed class HtmlTag : IHtmlElement
 
                 var separatorIndex = styleEntry.IndexOf(':');
                 var key = styleEntry.Substring(0, separatorIndex);
-                var value = styleEntry.Substring(
-                    separatorIndex + 1,
-                    styleEntry.Length - separatorIndex - 1
-                );
+                var value = styleEntry.Substring(separatorIndex + 1);
                 styles[key] = value;
             }
 
@@ -837,7 +834,10 @@ public sealed class HtmlTag : IHtmlElement
                 htmlTag = tagBuilder.Attributes.Aggregate(
                     htmlTag,
                     (tag, attribute) =>
-                        tag.Attribute(attribute.Key, HtmlEntity.DeEntitize(attribute.Value))
+                        tag.Attribute(
+                            attribute.Key,
+                            HtmlEntity.DeEntitize(attribute.Value ?? string.Empty)
+                        )
                 );
             }
 


### PR DESCRIPTION
## Summary

- Cross-compile library and tests to `net8.0;net9.0;net10.0`
- Update NuGet packages: `Microsoft.NET.Test.Sdk` 17.10.0 → 18.4.0, `coverlet.collector` 6.0.4 → 10.0.0, `xunit.runner.console` 2.9.2 → 2.9.3, `FluentAssertions` 6.12.0 → 8.9.0, `HtmlAgilityPack` 1.11.71 → 1.12.4
- Modernize CI: `actions/checkout@v4`, `codecov/codecov-action@v6`, add `actions/setup-dotnet@v4` with explicit 8.x/9.x/10.x SDK versions, add explicit restore and build steps

## Test plan

- [ ] CI passes tests on all three target frameworks (net8.0, net9.0, net10.0)
- [ ] Code coverage report uploads successfully to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)