### PR TITLE
Migrate xUnit from v2 to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,11 +9,7 @@
     </PackageVersion>
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.console" Version="2.9.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HtmlBuilders.Tests/HtmlBuilders.Tests.csproj
+++ b/HtmlBuilders.Tests/HtmlBuilders.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
@@ -8,11 +9,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.console">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- Replaces `xunit` 2.9.3 with `xunit.v3` 3.2.2 in `Directory.Packages.props`
- Removes `xunit.runner.console` (no longer needed in v3)
- Sets `<OutputType>Exe</OutputType>` in the test project (required by xUnit v3)
- All 288 tests pass across .NET 8, 9, and 10

No test code changes were required — the test suite is entirely synchronous so there was no need to thread `TestContext.Current.CancellationToken` through.

## Test plan

- [x] `dotnet build --configuration Release` — clean, 0 warnings
- [x] `dotnet test --configuration Release` — 288 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)